### PR TITLE
CCL on windows doesn't read ~/.ccl-init.lisp

### DIFF
--- a/impl-util.lisp
+++ b/impl-util.lisp
@@ -36,6 +36,9 @@
   (:implementation abcl
     ".abclrc")
   (:implementation ccl
+    #+win32
+    "ccl-init.lisp"
+    #-win32
     ".ccl-init.lisp")
   (:implementation clisp
     ".clisprc.lisp")


### PR DESCRIPTION
CCL on windows looks for "~/ccl-init.lisp", and ignores the "~/.ccl-init.lisp" that quicklisp adds to.

According to http://openmcl.clozure.com/manual/chapter2.4.html ~/ccl-init.lisp is the first thing it checks, then falls back to "~/.ccl-init.lisp" on unixy systems.  This patch simply changes the default init file QL edits to "~/ccl-init.lisp", although probing for which init file is actually there might be a better (albeit much more involved) change.
