### PR TITLE
Suitable init file for Clozure CL

### DIFF
--- a/impl-util.lisp
+++ b/impl-util.lisp
@@ -61,7 +61,9 @@
     #+windows
     "ccl-init.lisp"
     #-windows
-    ".ccl-init.lisp")
+    (if (probe-file "home:ccl-init.lisp")
+        "ccl-init.lisp"
+        ".ccl-init.lisp"))
   (:implementation clisp
     ".clisprc.lisp")
   (:implementation ecl


### PR DESCRIPTION
If ~/ccl-init.lisp exists then ql:add-to-init-file should add its magic there instead of ~/.ccl-init.lisp since CCL tries to load ~/ccl-init.lisp first and ignores ~/.ccl-init.lisp if successful.
