### PR TITLE
Support for finding projects in tarballs

### DIFF
--- a/packed.lisp
+++ b/packed.lisp
@@ -1,0 +1,26 @@
+;;;; packed.lisp
+
+;;;
+;;; Support for finding systems inside tarballs
+;;;
+
+(in-package #:quicklisp-client)
+
+(defun packed-projects-searcher (system-name)
+  "This function is added to ASDF:*SYSTEM-DEFINITION-SEARCH-FUNCTIONS*
+to use the packed projects anywhere in ASDF:*CENTRAL-REGISTRY*."
+  (let ((tar (qmerge "tmp/release-install.tar")))
+    (dolist (dir asdf:*central-registry*)
+      (dolist (archive (merge-pathnames "*.tar.gz" dir))
+        (unless (probe-directory (subseq (namestring archive) 0
+                                         (- (length (namestring archive)) 7)))
+          (ensure-directories-exist tar)
+          (gunzip archive tar)
+          (pushnew (unpack-tarball tar :directory dir)
+                   asdf:*central-registry*
+                   :test #'string=
+                   :key (lambda (path)
+                          (etypecase path
+                            (stringp path)
+                            (pathname (namestring path)))))
+          (asdf:find-system system-name))))))

--- a/setup.lisp
+++ b/setup.lisp
@@ -200,6 +200,7 @@
     (setf asdf:*system-definition-search-functions*
           (append asdf:*system-definition-search-functions*
                   (list 'local-projects-searcher
+                        'packed-projects-searcher
                         'system-definition-searcher))))
   (let ((files (nconc (directory (qmerge "local-init/*.lisp"))
                       (directory (qmerge "local-init/*.cl")))))


### PR DESCRIPTION
Hi Xach,

For deployment of my internal projects I needed a way to distribute custom libraries as a single file a la java jars (the obvious choice being tarballs).  As quicklisp has all the pieces needed for that, I've just re-used them and added a separate searcher function, that searches in ASDF:_CENTRAL-REGISTRY_ dirs for tarballs and unpacks them in the same dir.

I though that this may be an interesting addition to quicklisp-client.   The current implementation is more of a proof-of-concept sort, as it doesn't involve ASDF source registry (should it?) and unpacks the tarballs in-place (probably, there should be a more robust variant).  If you have any ideas, how to improve that, I'm ready to implement them.

Vsevolod
