### PR TITLE
Patch to allow Quicklisp to download and install systems named by :defsystem-depends-on

### DIFF
--- a/quicklisp/setup.lisp
+++ b/quicklisp/setup.lisp
@@ -61,12 +61,19 @@
   system given to load is not available via ASDF or a Quicklisp
   dist."))
 
+(defun asdf-find-system-try-harder (name)
+  (handler-bind
+    ((asdf::load-system-definition-error
+       #'(lambda (c) (ql:quickload (asdf::missing-requires (asdf::error-condition c)))
+           (invoke-restart 'asdf::reinitialize-source-registry-and-retry))))
+    (asdf:find-system name nil)))
+
 (defun compute-load-strategy (name)
   (setf name (string-downcase name))
   (let ((asdf-systems '())
         (quicklisp-systems '()))
     (labels ((recurse (name)
-               (let ((asdf-system (asdf:find-system name nil))
+               (let ((asdf-system (asdf-find-system-try-harder name))
                      (quicklisp-system (find-system name)))
                  (cond (asdf-system
                         (push asdf-system asdf-systems))


### PR DESCRIPTION
Here is a patch which enables Quicklisp to download and install systems named by :defsystem-depends-on. This helps if an ASDF component requires some package; with this patch, the required package is handled by Quicklisp, and without it, the package would have to be installed by hand before trying to use the component.

The use case that I have in mind is using ASDF to load Maxima packages. Maxima has its own language and packages can be written in that language. I have elsewhere ([project maxima-asdf](https://github.com/robert-dodier/maxima-asdf)) defined an ASDF component :maxima-file that tells how to handle Maxima files. In order to make such systems loadable by Quicklisp, it's necessary for the .asd file to have :defsystem-depends-on ("maxima") and this patch tells Quicklisp what to do with such dependencies.

Hope this helps in some way.