### PR TITLE
backticks?

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 all: gzip
-	git archive --format=tar version-`cat quicklisp/version.txt` quicklisp/ > quicklisp.tar
+	git archive --format=tar version-$(cat quicklisp/version.txt) quicklisp/ > quicklisp.tar
 	gzip -fnk9 quicklisp.tar
 
 gzip:
-	gzip -fnk9 setup.lisp asdf.lisp
+	gzip -fnk9 {setup,asdf}.lisp # maybe not. brace expansion is only available in bash
 
 clean:
 	rm -f quicklisp.tar quicklisp.tar.gz setup.lisp.gz asdf.lisp.gz
 
 tag:
-	test -z "`git status -s quicklisp/ asdf.lisp setup.lisp`"
-	git tag version-`cat quicklisp/version.txt`
+	test -z "$(git status -s quicklisp/ asdf.lisp setup.lisp)"
+	git tag version-$(cat quicklisp/version.txt)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all: gzip
 	gzip -fnk9 quicklisp.tar
 
 gzip:
-	gzip -fnk9 {setup,asdf}.lisp # maybe not. brace expansion is only available in bash
+	gzip -fnk9 setup.lisp asdf.lisp
 
 clean:
 	rm -f quicklisp.tar quicklisp.tar.gz setup.lisp.gz asdf.lisp.gz


### PR DESCRIPTION
Maybe would be a good time to get rid of backticks. They are need only on very old legacy systems with non posix compliable shells and probably there is not a lot of them still around. 

$() is more readable IMHO, works in sh, bash and any other Posix compliant shells, and is easier to maintain and more safer.