### PR TITLE
Add feature to make quicklisp tree available to ASDF without quicklisp being loaded

### DIFF
--- a/quicklisp/client.lisp
+++ b/quicklisp/client.lisp
@@ -48,14 +48,16 @@
 (defun system-list ()
   (provided-systems t))
 
-(defun update-dist (dist &key (prompt t))
+(defun update-dist (dist &key (prompt t) (cleanp t))
   (when (stringp dist)
     (setf dist (find-dist dist)))
   (let ((new (available-update dist)))
     (cond (new
            (show-update-report dist new)
            (when (or (not prompt) (press-enter-to-continue))
-             (update-in-place dist new)))
+             (update-in-place dist new)
+             (when cleanp
+               (clean dist))))
           ((not (subscribedp dist))
            (format t "~&You are not subscribed to ~S."
                    (name dist)))

--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -141,6 +141,14 @@ quicklisp at CL startup."
         (write-init-forms stream)))
     init-file))
 
+(defun configure-asdf (&optional (filename #p"50-quicklisp.conf"))
+  (let ((asdf-conf (merge-pathnames filename
+                                    (asdf:user-source-registry-directory))))
+    (with-open-file (out asdf-conf
+                         :direction :output
+                         :if-exists :error)
+      (prin1 `(:tree ,*quicklisp-home*) out))
+    asdf-conf))
 
 
 ;;;

--- a/quicklisp/package.lisp
+++ b/quicklisp/package.lisp
@@ -60,9 +60,10 @@
   (:documentation
    "Utility functions that require implementation-specific
    functionality.")
-  (:use #:cl #:ql-impl)
+  (:use #:cl #:ql-impl #:ql-setup)
   (:export #:call-with-quiet-compilation
            #:add-to-init-file
+           #:configure-asdf
            #:rename-directory
            #:delete-directory
            #:probe-directory
@@ -322,6 +323,7 @@
            #:update-all-dists
            #:available-dist-versions
            #:add-to-init-file
+           #:configure-asdf
            #:use-only-quicklisp-systems
            #:write-asdf-manifest-file
            #:where-is-system


### PR DESCRIPTION
We discussed this briefly on #lisp, together with a hint by quicklisp-bootstrap this would allow users to use Quicklisp-installed software through ASDF without having loaded Quicklisp. 29cb626 is so that ASDF won't find any old systems.

Consider this a request for comments, as I am unequipped to evaluate the possible impact of these changes.