### PR TITLE
support other than gz

### DIFF
--- a/quicklisp/bundle.lisp
+++ b/quicklisp/bundle.lisp
@@ -156,12 +156,8 @@
 (defmethod unpack-release (release target)
   (let ((*default-pathname-defaults* (truename
                                       (ensure-directories-exist target)))
-        (archive (ensure-local-archive-file release))
-        (temp-tar (ensure-directories-exist
-                   (ql-setup:qmerge "tmp/bundle.tar"))))
-    (ql-gunzipper:gunzip archive temp-tar)
-    (ql-minitar:unpack-tarball temp-tar :directory "software/")
-    (delete-file temp-tar)
+        (archive (ensure-local-archive-file release)))
+    (extract archive "software/" :temp-tar (ql-setup:qmerge "tmp/bundle.tar"))
     release))
 
 (defmethod unpack-releases ((bundle bundle) target)

--- a/quicklisp/client-update.lisp
+++ b/quicklisp/client-update.lisp
@@ -51,7 +51,7 @@
     ;; Fetch and unpack quicklisp.tar if needed
     (when new-client-tar-p
       (fetch-client-file-info (client-tar-info new-info) local-temp-tar)
-      (unpack-tarball local-temp-tar :directory work-directory))
+      (extract local-temp-tar work-directory))
     ;; Fetch setup.lisp if needed
     (when new-setup-p
       (fetch-client-file-info (setup-info new-info) local-setup))

--- a/quicklisp/dist.lisp
+++ b/quicklisp/dist.lisp
@@ -767,16 +767,13 @@ the given NAME."
 
 (defmethod install ((release release))
   (let ((archive (ensure-local-archive-file release))
-        (tar (qmerge "tmp/release-install.tar"))
         (output (relative-to (dist release)
                              (make-pathname :directory
                                             (list :relative "software"))))
         (tracking (install-metadata-file release)))
-    (ensure-directories-exist tar)
     (ensure-directories-exist output)
     (ensure-directories-exist tracking)
-    (gunzip archive tar)
-    (unpack-tarball tar :directory output)
+    (extract archive output :temp-tar (qmerge "tmp/release-install.tar"))
     (ensure-directories-exist tracking)
     (with-open-file (stream tracking
                             :direction :output

--- a/quicklisp/extract.lisp
+++ b/quicklisp/extract.lisp
@@ -1,0 +1,28 @@
+(in-package #:ql-extract)
+
+(defvar *extract-type-functions*
+  '(("tar" . tar-extract)
+    ("gz" . tgz-extract))
+  "assoc list to decide which extract-function are called by EXTRACT function.")
+
+(defun tar-extract (archive directory &key &allow-other-keys)
+  "extract tar."
+  (unpack-tarball archive :directory directory))
+
+(defun tgz-extract (archive directory &key temp-tar)
+  "extract tgz."
+  (ensure-directories-exist temp-tar)
+  (gunzip archive temp-tar)
+  (tar-extract temp-tar directory)
+  (delete-file temp-tar))
+
+(defun extract (archive directory &rest rest)
+  "extract archive depends on type of a file."
+  (let* ((name (namestring archive))
+         (type (subseq name
+                       (1+ (position
+                            #\. name :from-end t))))
+         (call (cdr (assoc type *extract-type-functions* :test 'equal))))
+    (if call
+        (apply call archive directory rest)
+        (error "Unknown archive type ~S" archive))))

--- a/quicklisp/package.lisp
+++ b/quicklisp/package.lisp
@@ -125,6 +125,17 @@
   (:use #:cl)
   (:export #:gunzip))
 
+(defpackage #:ql-extract
+  (:documentation
+   "An simple dispatcher to extract archives.")
+  (:use #:cl
+        #:ql-minitar
+        #:ql-gunzipper)
+  (:export #:extract
+           #:*extract-type-functions*
+           #:tgz-extract
+           #:tar-extract))
+
 (defpackage #:ql-cdb
   (:documentation
    "Read and write CDB files; code adapted from ZCDB.")
@@ -142,8 +153,7 @@
         #:ql-util
         #:ql-http
         #:ql-setup
-        #:ql-gunzipper
-        #:ql-minitar)
+        #:ql-extract)
   (:intern #:dist-version
            #:dist-url)
   (:import-from #:ql-impl-util
@@ -260,7 +270,7 @@
 (defpackage #:ql-bundle
   (:documentation
    "A package for supporting the QL:BUNDLE-SYSTEMS function.")
-  (:use #:cl #:ql-dist #:ql-impl-util)
+  (:use #:cl #:ql-dist #:ql-impl-util #:ql-extract)
   (:shadow #:find-system
            #:find-release)
   (:export #:bundle
@@ -287,8 +297,7 @@
         #:ql-http
         #:ql-setup
         #:ql-config
-        #:ql-minitar
-        #:ql-gunzipper)
+        #:ql-extract)
   (:shadow #:uninstall)
   (:shadowing-import-from #:ql-dist
                           #:dist-version


### PR DESCRIPTION
It is similar to what I send pull request for ``FETCH`` scheme before.
I'm currently maintaining patch for quicklisp https://github.com/roswell/roswell/blob/master/lisp/patch-quicklisp.lisp
and why I'm having this is because I notice multprocessed ``ql:quickload`` sometimes stack because of reuse of same named temporal tar file.

This patch would never fix the problem but I can shorten my patch for quicklisp.
Simultaneously, I think it'll help to support xz or something better than gz.
