### PR TITLE
Files unpacked from tarballs bear the archived mtime (SBCL, Allegro)

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -174,6 +174,21 @@ quicklisp at CL startup."
   (:implementation clisp
     (nth-value 2 (ql-clisp:probe-pathname pathname))))
 
+;;;
+;;; Set file date
+;;;
+
+(definterface set-file-date (pathname access-time modification-time)
+  (:documentation "Set the access and modification time of the file designated
+  by PATHNAME as a unix time (seconds since 1970-01-01).")
+  (:implementation t
+    t)
+  (:implementation allegro
+                   (ql-allegro:utime pathname
+                                     (ql-allegro:unix-to-universal-time access-time)
+                                     (ql-allegro:unix-to-universal-time modification-time)))
+  (:implementation sbcl
+    (ql-sbcl:utime pathname access-time modification-time)))
 
 ;;;
 ;;; Deleting a directory tree
@@ -337,4 +352,3 @@ potentially dead symlinks."
           (if (directoryp entry)
               (push entry directories-to-process)
               (funcall fun entry)))))))
-

--- a/quicklisp/impl.lisp
+++ b/quicklisp/impl.lisp
@@ -132,8 +132,13 @@
   (:documentation
    "Allegro Common Lisp - http://www.franz.com/products/allegrocl/")
   (:class allegro)
+  (:prep
+   (require :osi))
   (:reexport-from #:socket
                   #:make-socket)
+  (:reexport-from #:excl.osi
+                  #:unix-to-universal-time
+                  #:utime)
   (:reexport-from #:excl
                   #:file-directory-p
                   #:delete-directory
@@ -289,7 +294,8 @@
    (require 'sb-bsd-sockets))
   (:intern #:host-network-address)
   (:reexport-from #:sb-posix
-                  #:rmdir)
+                  #:rmdir
+                  #:utime)
   (:reexport-from #:sb-ext
                   #:compiler-note
                   #:native-namestring)


### PR DESCRIPTION
This is the default behaviour of GNU tar and useful in cases where the
archives of a dist are downloaded, but not yet unpacked.

Implementations other than Allegro and SBCL retain the current
behaviour: the modification time of the file is the time when the
archive was unpacked.