### PR TITLE
Support headers when fetching tarballs

### DIFF
--- a/quicklisp/config.lisp
+++ b/quicklisp/config.lisp
@@ -19,6 +19,22 @@
                      :directory (list* :relative directory-parts))
       base)))
 
+(defun config-paths (&optional (path-string "**/*"))
+  "Return all config paths that match PATH-STRING."
+  (let* ((base (qmerge "config/"))
+         (pathname-to-match (merge-pathnames
+                             (merge-pathnames
+                              (make-pathname :type "txt")
+                              path-string)
+                             base))
+         (pathnames (directory pathname-to-match)))
+    (mapcar (lambda (p)
+              (let ((enough-name (enough-namestring p base)))
+                ;; Strip off the .txt
+                (namestring (make-pathname :directory (pathname-directory enough-name)
+                                           :name (pathname-name enough-name)))))
+            pathnames)))
+
 (defun config-value (path)
   (let ((file (config-value-file-pathname path)))
     (with-open-file (stream file :if-does-not-exist nil)

--- a/quicklisp/package.lisp
+++ b/quicklisp/package.lisp
@@ -106,7 +106,8 @@
            #:path
            #:url
            #:*maximum-redirects*
-           #:*default-url-defaults*)
+           #:*default-url-defaults*
+           #:headers-for-url)
   (:export #:fetch-error
            #:unexpected-http-status
            #:unexpected-http-status-code

--- a/quicklisp/package.lisp
+++ b/quicklisp/package.lisp
@@ -31,7 +31,8 @@
   (:documentation
    "Getting and setting persistent configuration values.")
   (:use #:cl #:ql-util #:ql-setup)
-  (:export #:config-value))
+  (:export #:config-value
+           #:config-paths))
 
 (defpackage #:ql-impl
   (:documentation


### PR DESCRIPTION
I've exported `headers-for-url` because I'm planning to submit a PR to quicklisp-https to use it.

I'd really like to add the ability for headers to be retrieved by specifying a command (for instance to decrypt a file so a private token isn't sitting unencrypted in the file system). But that's a pain to support on all the lisps Quicklisp runs on, so I'm going to punt it until ASDF 3 is required and `uiop:run-program` becomes available.