### PR TITLE
Handle directory scans nicely when SBCL is invoked without UTF-8

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -251,8 +251,13 @@ quicklisp at CL startup."
      (directory (merge-pathnames *wild-entry* directory))
      (directory (merge-pathnames *wild-relative* directory))))
   (:implementation sbcl
-    (directory (merge-pathnames *wild-entry* directory)
-               #+sbcl :resolve-symlinks #+sbcl nil)))
+    (handler-case
+        (directory (merge-pathnames *wild-entry* directory)
+                   #+sbcl :resolve-symlinks #+sbcl nil)
+      (#+sbcl sb-int:c-string-decoding-error #-sbcl t (err)
+        (format t "While scanning directories:~%~a~%~a~%~a" err
+                "Some files need UTF-8 support. Consider setting"
+                "LC_CTYPE=en_US.UTF-8 before invoking SBCL or Emacs")))))
 
 (defimplementation (directory-entries :qualifier :around) (directory)
   ;; Don't return any entries when called with a non-directory


### PR DESCRIPTION
If filenames in local-projects/ contained non-ASCII characters
when SBCL was invoked with LC_CTYPE=C we got error
"ASCII c-string decoding error: the octet sequence #(x) cannot be decoded"
and the local-projects/system-index.txt was left empty.
Now a message is shown and system-index.txt is created.
Fixes issue #152