### PR TITLE
Change delete-dir to delete-directory for clisp

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -273,7 +273,7 @@ quicklisp at CL startup."
   (:implementation clasp
     (ql-clasp:rmdir entry))
   (:implementation clisp
-    (ql-clisp:delete-dir entry))
+    (ql-clisp:delete-directory entry))
   (:implementation cmucl
     (ql-cmucl:unix-rmdir (namestring entry)))
   (:implementation scl

--- a/quicklisp/impl.lisp
+++ b/quicklisp/impl.lisp
@@ -189,7 +189,7 @@
   (:reexport-from #:socket
                   #:socket-connect)
   (:reexport-from #:ext
-                  #:delete-dir
+                  #:delete-directory
                   #:rename-directory
                   #:probe-directory
                   #:probe-pathname


### PR DESCRIPTION
Here's a ref to the docs
https://clisp.sourceforge.io/impnotes/dir-func.html

And a user here had noticed the bug:
https://www.linuxquestions.org/questions/slackware-14/follow-on-re-clisp-re-build-using-current-does-clisp-on-current-work-with-quicklisp-4175627366/