### PR TITLE
Initial port to the Mezzano Lisp Operating System

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -68,6 +68,8 @@
     ".clisprc.lisp")
   (:implementation ecl
     ".eclrc")
+  (:implementation mezzano
+    "init.lisp")
   (:implementation mkcl
     ".mkclrc")
   (:implementation lispworks
@@ -245,6 +247,8 @@ quicklisp at CL startup."
                 #+ecl :resolve-symlinks #+ecl nil)
      (directory (merge-pathnames *wild-relative* directory)
                 #+ecl :resolve-symlinks #+ecl nil)))
+  (:implementation mezzano
+    (directory (merge-pathnames *wild-entry* directory)))
   (:implementation mkcl
     (setf directory (truename directory))
     (nconc

--- a/quicklisp/impl.lisp
+++ b/quicklisp/impl.lisp
@@ -259,6 +259,14 @@
                   #:socket-connect
                   #:socket-make-stream))
 
+;;; Mezzano
+
+(define-implementation-package :mezzano #:ql-mezzano
+  (:documentation "Mezzano Lisp Operating System - https://github.com/froggey/Mezzano")
+  (:class mezzano)
+  (:reexport-from #:mezzano.network.tcp
+                  #:tcp-stream-connect))
+
 ;;; MKCL
 
 (define-implementation-package :mkcl #:ql-mkcl

--- a/quicklisp/network.lisp
+++ b/quicklisp/network.lisp
@@ -65,6 +65,9 @@
                                  :input t
                                  :output t
                                  :buffering :full)))
+  (:implementation mezzano
+    (ql-mezzano:tcp-stream-connect host port
+                                   :element-type '(unsigned-byte 8)))
   (:implementation mkcl
     (let* ((endpoint (ql-mkcl:host-ent-address
                       (ql-mkcl:get-host-by-name host)))

--- a/quicklisp/package.lisp
+++ b/quicklisp/package.lisp
@@ -52,6 +52,7 @@
            #:ecl
            #:gcl
            #:lispworks
+           #:mezzano
            #:mkcl
            #:scl
            #:sbcl))


### PR DESCRIPTION
This commit adds implementations of Quicklisp interfaces for the
Mezzano operating system.