### PR TITLE
Fix can't download redirect file issue

### DIFF
--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -855,5 +855,6 @@ the indexes in the header accordingly."
                  (incf redirect-count)
                  (setf url (merge-urls new-urlstring
                                        url))
-                 (format stream "~&; Redirecting to ~A~%" url))
+                 (format stream "~&; Redirecting to ~A~%" url)
+                 (setf connect-url (or (url *proxy-url*) url)))
                (return (values header (and file (probe-file file)))))))))))


### PR DESCRIPTION
Fixed [windows run (ql:quickload 'repl-utilities) error #179](https://github.com/quicklisp/quicklisp-client/issues/179)