### PR TITLE
fix directory-entries for Allegro

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -199,12 +199,16 @@ quicklisp at CL startup."
   (:documentation "Return all directory entries of DIRECTORY as a
   list, or NIL if there are no directory entries. Excludes the \".\"
   and \"..\" entries.")
-  (:implementation allegro
-    (directory directory
-               #+allegro :directories-are-files
-               #+allegro nil
-               #+allegro :follow-symbolic-links
-               #+allegro nil))
+  (:implementation
+   allegro
+   (when (let* ((namestring (namestring directory))
+		(lastchar (subseq namestring (1- (length namestring)))))
+	   (member lastchar '("/" "\\") :test #'string-equal))
+     (directory directory
+		#+allegro :directories-are-files
+		#+allegro nil
+		#+allegro :follow-symbolic-links
+		#+allegro nil)))
   (:implementation abcl
     (directory (merge-pathnames *wild-entry* directory)
                #+abcl :resolve-symlinks #+abcl nil))


### PR DESCRIPTION
Allegro's `directory` with `:follow-symbolic-links? nil` returns a symbolic link directory without its trailing `/` (even though `directoryp` returns `t` for it), which causes confusion when trying to get its `directory-entries`.  This fixes it by checking for the trailing slash before calling `directory`. Maybe this check could be done in `directoryp` instead? 

Anyway it turns out this was the cause of hanging behavior with quicklisp loading systems and doing `register-local-projects` on Allegro.  
