### PR TITLE
Handle unbound canonical-distinfo-url for ql:bundle-systems of ultralisp

### DIFF
--- a/quicklisp/dist.lisp
+++ b/quicklisp/dist.lisp
@@ -834,6 +834,11 @@ the given NAME."
   (setf (slot-value dist 'release-index)
         (make-hash-table :test 'equal)))
 
+(defmethod slot-unbound (class (dist dist) (slot (eql 'canonical-distinfo-url)))
+  (declare (ignore class))
+  (setf (slot-value dist 'canonical-distinfo-url)
+        (distinfo-subscription-url dist)))
+
 
 ;;;
 ;;; Systems


### PR DESCRIPTION
This fixes a slot unbound error when trying to use `(ql:bundle-systems)` and you have ultralisp dist enabled, which does not define a canonical-distinfo-url.  