### PR TITLE
Now QL supports distributions with slash in their names

### DIFF
--- a/quicklisp/dist.lisp
+++ b/quicklisp/dist.lisp
@@ -497,7 +497,9 @@
 (defun dist-name-pathname (name)
   "Return the pathname that would be used for an installed dist with
 the given NAME."
-  (qmerge (make-pathname :directory (list :relative "dists" name))))
+  (qmerge (make-pathname :directory (list* :relative
+                                           "dists"
+                                           (split-slashes name)))))
 
 (defmethod slot-unbound (class (dist dist) (slot (eql 'base-directory)))
   (declare (ignore class))
@@ -577,7 +579,7 @@ the given NAME."
 
 (defun standard-dist-enumeration-function ()
   "The default function used for producing a list of dist objects."
-  (loop for file in (directory (qmerge "dists/*/distinfo.txt"))
+  (loop for file in (directory (qmerge "dists/**/distinfo.txt"))
         collect (make-dist-from-file file)))
 
 (defun all-dists ()

--- a/quicklisp/package.lisp
+++ b/quicklisp/package.lisp
@@ -12,6 +12,7 @@
            #:delete-file-if-exists
            #:ensure-file-exists
            #:split-spaces
+           #:split-slashes
            #:first-line
            #:file-size
            #:safely-read

--- a/quicklisp/utils.lisp
+++ b/quicklisp/utils.lisp
@@ -56,29 +56,31 @@
   (when (probe-file pathname)
     (delete-file pathname)))
 
-(defun split-spaces (line)
+(defun split (line delimiter)
   (let ((words '())
         (mark 0)
         (pos 0))
     (labels ((finish ()
                (setf pos (length line))
                (save)
-               (return-from split-spaces (nreverse words)))
+               (return-from split (nreverse words)))
              (save ()
                (when (< mark pos)
                  (push (subseq line mark pos) words)))
              (mark ()
                (setf mark pos))
              (in-word (char)
-               (case char
-                 (#\Space
+               (cond
+                 ((char= char
+                         delimiter)
                     (save)
                     #'in-space)
                  (t
                     #'in-word)))
              (in-space (char)
-               (case char
-                 (#\Space
+               (cond
+                 ((char= char
+                         delimiter)
                     #'in-space)
                  (t
                     (mark)
@@ -87,6 +89,12 @@
         (dotimes (i (length line) (finish))
           (setf pos i)
           (setf state (funcall state (char line i))))))))
+
+(defun split-spaces (line)
+  (split line #\Space))
+
+(defun split-slashes (line)
+  (split line #\/))
 
 (defun first-line (file)
   (with-open-file (stream file)


### PR DESCRIPTION
This makes it possible to use custom distributions, hosted at [Ultralisp.org](https://ultralisp.org).
These custom distributions have names of form `username/dist-name` and
`distinfo.txt` file looks like this:

```
name: svetlyak40wt/my-forks
version: 20210112065000
distinfo-subscription-url: http://dist.ultralisp.org/svetlyak40wt/my-forks.txt
distinfo-template-url: http://dist.ultralisp.org/svetlyak40wt/my-forks/{{version}}/distinfo.txt
release-index-url: http://dist.ultralisp.org/svetlyak40wt/my-forks/20210112065000/releases.txt
system-index-url: http://dist.ultralisp.org/svetlyak40wt/my-forks/20210112065000/systems.txt
```

Such names also make sense as a URL's part. That is why I think
it is a good idea to support them in QuickLisp client.