### PR TITLE
quickload: allow thing to be any named thing

### DIFF
--- a/quicklisp/client.lisp
+++ b/quicklisp/client.lisp
@@ -34,7 +34,8 @@
         (setf systems (list systems)))
       (dolist (thing systems systems)
         (flet ((ql ()
-                 (autoload-system-and-dependencies thing :prompt prompt)))
+                 (autoload-system-and-dependencies (name thing)
+                                                   :prompt prompt)))
           (tagbody :start
              (restart-case (if verbose
                                (ql)

--- a/quicklisp/dist.lisp
+++ b/quicklisp/dist.lisp
@@ -382,6 +382,12 @@
 (defmethod system ((name string))
   (find-system (string-downcase name)))
 
+(defmethod name ((string string))
+  string)
+
+(defmethod name ((symbol symbol))
+  (symbol-name symbol))
+
 ;;;
 ;;; Dists
 ;;;


### PR DESCRIPTION
Hi,

This is a minor problem but I often use `system-apropos-list` to find the exact name of a system whose name I don't quite remember, or when trying to see if some project is already available on Quicklisp. In such cases, the return value of the function is a list of system objects. I have then to get the name of such a system to `quickload` it, because passing directly a system is not supported (as far as I know, I'd be interested to know if I am missing a better way to do this).

The patch calls `name` on the `thing` being given to `quickload`, and adds a method for `name` specializing on `string` values. That makes this interaction possible:

    USER> (system-apropos-list "classo")
    (#<QL-DIST:SYSTEM classowary ...> ...)

    USER> (quickload (first *))
    To load "classowary":
    Load 1 ASDF system:
      classowary
    ; Loading "classowary"

    (#<QL-DIST:SYSTEM classowary ...>)

The patch is merely here to discuss this particular problem I had and how I solved it on my machine, feel free to edit it or ignore it.

Thank you

