### PR TITLE
Fix various stylistic issues

### DIFF
--- a/quicklisp/client-info.lisp
+++ b/quicklisp/client-info.lisp
@@ -219,11 +219,11 @@
 
 (defun local-client-info ()
   (let ((info-file (qmerge "client-info.sexp")))
-    (if (probe-file info-file)
-        (load-client-info info-file)
-        (progn
-          (warn "Missing client-info.sexp, using mock info")
-          (mock-client-info)))))
+    (cond ((probe-file info-file)
+           (load-client-info info-file))
+          (t
+           (warn "Missing client-info.sexp, using mock info")
+           (mock-client-info)))))
 
 (defun newest-client-info (&optional (info (local-client-info)))
   (let ((latest (subscription-url info)))

--- a/quicklisp/client.lisp
+++ b/quicklisp/client.lisp
@@ -99,7 +99,7 @@
                                                exclude-local-projects)
   "Write a list of system file pathnames to OUTPUT-FILE, one per line,
 in order of descending QL-DIST:PREFERENCE."
-  (when (or (eql output-file nil)
+  (when (or (null output-file)
             (eql output-file t))
     (setf output-file (qmerge "manifest.txt")))
   (with-open-file (stream output-file

--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -849,7 +849,7 @@ the indexes in the header accordingly."
                          :status-code (status header))))
            (if (and follow-redirects (<= 300 (status header) 399))
                (let ((new-urlstring (ascii-header-value "location" header)))
-                 (when (not new-urlstring)
+                 (unless new-urlstring
                    (error "Redirect code ~D received, but no Location: header"
                           (status header)))
                  (incf redirect-count)

--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -322,11 +322,11 @@
 
 (defun full-proxy-path (host port path)
   (format nil "~:[http~;https~]://~A~:[:~D~;~*~]~A"
-          (eql port 443)
+          (= port 443)
           host
           (or (null port)
-              (eql port 80)
-              (eql port 443))
+              (= port 80)
+              (= port 443))
           port
           path))
 

--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -226,7 +226,8 @@
     (call-processor fun cbuf (start cbuf) (end cbuf))))
 
 (defun multi-cmatch (matchers cbuf)
-  (let (start end)
+  (let ((start nil)
+        (end nil))
     (dolist (matcher matchers (values start end))
       (multiple-value-bind (s e)
           (match matcher (data cbuf)

--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -80,8 +80,7 @@
        ,@(mapcar (lambda (case)
                    (destructuring-bind (keys &rest body)
                        case
-                     `(,(if (eql keys t)
-                            t
+                     `(,(or (eql keys t)
                             (convert-case-keys keys))
                         ,@body)))
                  cases))))

--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -112,23 +112,23 @@
     (with-slots (pattern pos)
         matcher
       (loop
-       (cond ((= pos match-end)
-              (let ((match-start (- i pos)))
-                (setf pos 0)
-                (setf (matchedp matcher) t)
-                (return (values match-start (+ match-start match-end)))))
-             ((= i end)
-              (return nil))
-             ((= (aref pattern pos)
-                 (aref input i))
-              (incf i)
-              (incf pos))
-             (t
-              (if error
-                  (error 'match-failure)
-                  (if (zerop pos)
-                      (incf i)
-                      (setf pos 0)))))))))
+        (cond ((= pos match-end)
+               (let ((match-start (- i pos)))
+                 (setf pos 0)
+                 (setf (matchedp matcher) t)
+                 (return (values match-start (+ match-start match-end)))))
+              ((= i end)
+               (return nil))
+              ((= (aref pattern pos)
+                  (aref input i))
+               (incf i)
+               (incf pos))
+              (error
+               (error 'match-failure))
+              ((zerop pos)
+               (incf i))
+              (t
+               (setf pos 0)))))))
 
 (defun ascii-matcher (string)
   (make-instance 'matcher

--- a/quicklisp/http.lisp
+++ b/quicklisp/http.lisp
@@ -322,7 +322,7 @@
 
 (defun full-proxy-path (host port path)
   (format nil "~:[http~;https~]://~A~:[:~D~;~*~]~A"
-          (= port 443)
+          (eql port 443)
           host
           (or (null port)
               (= port 80)

--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -319,12 +319,12 @@ quicklisp at CL startup."
     (ql-ccl:delete-directory pathname)))
 
 (defimplementation (delete-directory-tree :qualifier :around) (pathname)
-  (if (directoryp pathname)
-      (call-next-method)
-      (progn
-        (warn "delete-directory-tree - not a directory, ~
-               deleting anyway -- ~s" pathname)
-        (delete-file pathname))))
+  (cond ((directoryp pathname)
+         (call-next-method))
+        (t
+         (warn "delete-directory-tree - not a directory, ~
+                deleting anyway -- ~s" pathname)
+         (delete-file pathname))))
 
 (defun map-directory-tree (directory fun)
   "Call FUN for every file in directory and all its subdirectories,

--- a/quicklisp/local-projects.lisp
+++ b/quicklisp/local-projects.lisp
@@ -49,10 +49,10 @@
 
 (defun local-project-system-files (pathname)
   "Return a list of system files under PATHNAME."
-  (let* ((files (matching-directory-files pathname
-                                          (lambda (file)
-                                            (equalp (pathname-type file)
-                                                    "asd")))))
+  (let ((files (matching-directory-files pathname
+                                         (lambda (file)
+                                           (equalp (pathname-type file)
+                                                   "asd")))))
     (setf files (sort files
                       #'string<
                       :key #'namestring))

--- a/quicklisp/network.lisp
+++ b/quicklisp/network.lisp
@@ -128,7 +128,7 @@
   closes the connection afterwareds via CLOSE-CONNECTION in an
   unwind-protect. See also WITH-CONNECTION.")
   (:implementation t
-    (let (connection)
+    (let ((connection nil))
       (unwind-protect
            (progn
              (setf connection (open-connection host port))

--- a/quicklisp/setup.lisp
+++ b/quicklisp/setup.lisp
@@ -16,7 +16,7 @@
                (unless system
                  (error "Unknown system ~S" name))
                (ensure-installed system)
-               (mapcar #'recurse (required-systems system))
+               (mapc #'recurse (required-systems system))
                name)))
     (with-consistent-dists
       (recurse name))))


### PR DESCRIPTION
Most of these changes are stylistic (improvements). Exceptions are:
- [Fix EQL on numbers](https://github.com/quicklisp/quicklisp-client/commit/fc5baddb65f9817a688bb175f2d51227d96b3244):
Using `=` to compare numbers is better, since `=` signals a type-error if supplied non-number, while `EQL` does not.
- [Fix needless list building in mapping operation](https://github.com/quicklisp/quicklisp-client/commit/1caa8a9f356513dea08c28ee64e5981e793591e9):
  `MAPC` improves performance when values are not used, since `MAPCAR` builds a list (consing), while `MAPC` does not.

Inspired by [lisp-critic](https://github.com/g000001/lisp-critic)/[40ants-critic](https://github.com/40ants/40ants-critic).