### PR TITLE
Handle symlinks to directories in LispWorks

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -247,9 +247,20 @@ quicklisp at CL startup."
     (directory (merge-pathnames *wild-entry* directory)
                #+scl :truenamep #+scl nil))
   (:implementation lispworks
-    (directory (merge-pathnames *wild-entry* directory)
+     ;; if the directory is a symlink and link transparency is false
+     ;; then it will have filename components which should be the last
+     ;; element of the directory component.  If that's the case then
+     ;; append them to the directory where they belong.
+     (let ((filename (file-namestring directory)))
+       (directory (merge-pathnames *wild-entry*
+                                   (if (not filename)
+                                       directory
+                                     (make-pathname
+                                      :directory (append (pathname-directory directory)
+                                                         (list filename))
+                                      :defaults directory)))
                #+lispworks :directories #+lispworks t
-               #+lispworks :link-transparency #+lispworks nil))
+               #+lispworks :link-transparency #+lispworks nil)))
   (:implementation ecl
     (nconc
      (directory (merge-pathnames *wild-entry* directory)


### PR DESCRIPTION
If a symlink points to a directory, then LW will, if link transparency is false (which it is) return its name as a filename from `directory`: as a name whose `file-namestring` is not `nil` in other words.  Deal with this in `directory-entries` by appending the name to the directory components.

This should deal with issue #226.

I think this is a better fix than PR #222 which currently has problems with packages.