### PR TITLE
Fix: Remove who-depends-on duplicates

### DIFF
--- a/quicklisp/misc.lisp
+++ b/quicklisp/misc.lisp
@@ -15,6 +15,8 @@
 (defun who-depends-on (system-name)
   "Return a list of names of systems that depend on SYSTEM-NAME."
   (setf system-name (string-downcase system-name))
-  (loop for system in (provided-systems t)
-        when (member system-name (required-systems system) :test 'string=)
-        collect (name system)))
+  (remove-duplicates
+   (loop for system in (provided-systems t)
+	 when (member system-name (required-systems system) :test 'string=)
+	 collect (name system))
+   :test #'string=))


### PR DESCRIPTION
Some systems were appearing multiple times when calling `who-depends-on`. 
That should be fixed with this patch.