### PR TITLE
remove duplicate code to update ASDF

### DIFF
--- a/setup.lisp
+++ b/setup.lisp
@@ -119,10 +119,9 @@ compiling asdf.lisp to a FASL and then loading it."
 ;;; ASDF. Thanks to Nikodemus Siivola for pointing out this issue.
 ;;;
 
-(let ((asdf-init (probe-file (qmerge "asdf-config/init.lisp"))))
-  (when asdf-init
-    (with-simple-restart (skip "Skip loading ~S" asdf-init)
-      (load asdf-init :verbose nil :print nil))))
+(let ((asdf-init (qmerge "asdf-config/init.lisp")))
+  (with-simple-restart (skip "Skip loading ~S" asdf-init)
+    (load asdf-init :verbose nil :print nil :if-does-not-exist nil)))
 
 (push (qmerge "quicklisp/") asdf:*central-registry*)
 


### PR DESCRIPTION
Commit 259a8d1dfc82d49f46c2127f4694f5526b612bb1 added these lines to supposedly update ASDF. However, a "asdf-config/init.lisp" file has never existed in asdf's, quicklisp-client's, or quicklisp-bootstrap's history according to `git log -- '**init.lisp'` in each project's tree, and the very same commit also introduced a more robust function to update ASDF.

It's possible I missed code to download or generate such a file, but it doesn't appear to be the case in the latest version of each project.

Tested on OpenBSD 7.6 by quickloading Alexandria on ABCL, ECL, and SBCL.