### PR TITLE
Check for custom init file name on SBCL. For `(ql:add-to-init-file)`

### DIFF
--- a/quicklisp/impl-util.lisp
+++ b/quicklisp/impl-util.lisp
@@ -75,7 +75,9 @@
   (:implementation lispworks
     ".lispworks")
   (:implementation sbcl
-    ".sbclrc")
+    (or (and (find-package :sb-ext)
+             (funcall sb-ext:*userinit-pathname-function*))
+        ".sbclrc"))
   (:implementation cmucl
     ".cmucl-init.lisp")
   (:implementation scl


### PR DESCRIPTION
```bash
$ sbcl
This is SBCL 2.5.0, an implementation of ANSI Common Lisp...
* (ql:add-to-init-file)
I will append the following lines to #P"/home/urmom/.sbclrc":
...

$ cat ~/.config/sbcl/sbclrc
(setf sb-ext:*userinit-pathname-function*
      (lambda () "~/.config/sbcl/sbclrc"))
 
$ sbcl --userinit ~/.config/sbcl/sbclrc
This is SBCL 2.5.0, an implementation of ANSI Common Lisp...
* (ql:add-to-init-file)
I will append the following lines to #P"~/.config/sbcl/sbclrc":
...
 ```