### PR TITLE
Remove unused function "recursively-install from 'quicklisp/setup.lisp'

### DIFF
--- a/quicklisp/setup.lisp
+++ b/quicklisp/setup.lisp
@@ -12,17 +12,6 @@
    (fresh-line)
    (finish-output)))
 
-(defun recursively-install (name)
-  (labels ((recurse (name)
-             (let ((system (find-system name)))
-               (unless system
-                 (error "Unknown system ~S" name))
-               (ensure-installed system)
-               (mapc #'recurse (required-systems system))
-               name)))
-    (with-consistent-dists
-      (recurse name))))
-
 (defclass load-strategy ()
   ((name
     :initarg :name


### PR DESCRIPTION
Hey there. 

This function is not being used, afaikt, so I made this PR to remove it.

Feel free to close it if there's any reason to keep it.

CHeers