### PR TITLE
Speed up constant database creation

### DIFF
--- a/quicklisp/cdb.lisp
+++ b/quicklisp/cdb.lisp
@@ -263,7 +263,6 @@ be (unsigned-byte 8) vectors."
     (write-cdb-u32 (length value) output)
     (write-sequence key output)
     (write-sequence value output)
-    (force-output output)
     (incf (end-of-records-position cdb-writer)
           (+ 8 (length key) (length value)))))
 
@@ -306,7 +305,7 @@ be available."
 cdb file."
   (write-hash-tables cdb-writer)
   (write-pointers cdb-writer)
-  (force-output (output cdb-writer)))
+  (finish-output (output cdb-writer)))
 
 
 (defvar *pointer-padding* (make-array 2048 :element-type '( unsigned-byte 8)))


### PR DESCRIPTION
There is no need to sync to disk every time a record is added, because in a constant database records are only added at database creation time, and the database is created in a temp file before being moved to the final file. A sync is only needed once after all records have been added. Further `force-output` is not a sync because it returns before completion. `finish-output` is a sync (to the extent that Common Lisp offers one).

With this patch, my systems.cdb gets created in 0.6 seconds instead of 44 seconds.